### PR TITLE
Fixed issues in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ Or clone the repo :
 
 .. code-block:: bash
 
-    $ git clone http://github.org/poulp/python-zenity.git
-    $ cd python-zenity/
+    $ git clone https://github.com/poulp/python-zenity.git
+    $ cd ./python-zenity
     $ python setup.py install
 
 Example


### PR DESCRIPTION
The link to the git file on GitHub was incorrect, as it pointed to github.org instead of github.com. This isn't an issue in current web browsers, but might pose an issue in other places (besides just not being correct).

Otherwise, there seemed to be a slight issue on line 30 of the file. This too was changed.